### PR TITLE
Move binding helpers from chainlink-evm and add new helper methods for promises

### DIFF
--- a/capabilities/blockchain/evm/bindings/common.go
+++ b/capabilities/blockchain/evm/bindings/common.go
@@ -1,0 +1,73 @@
+package bindings
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/evm"
+)
+
+type ContractInitOptions struct {
+	GasConfig *evm.GasConfig
+}
+
+type LogTrackingOptions[T any] struct {
+	MaxLogsKept   uint64 `protobuf:"varint,1,opt,name=max_logs_kept,json=maxLogsKept,proto3" json:"max_logs_kept,omitempty"`     // maximum number of logs to retain ( 0 = unlimited )
+	RetentionTime int64  `protobuf:"varint,2,opt,name=retention_time,json=retentionTime,proto3" json:"retention_time,omitempty"` // maximum amount of time to retain logs in seconds
+	LogsPerBlock  uint64 `protobuf:"varint,3,opt,name=logs_per_block,json=logsPerBlock,proto3" json:"logs_per_block,omitempty"`  // rate limit ( maximum # of logs per block, 0 = unlimited )
+	Filters       []T
+}
+
+type FilterOptions struct {
+	BlockHash []byte
+	FromBlock *big.Int
+	ToBlock   *big.Int
+}
+
+func ValidateLogTrackingOptions[T any](opts *LogTrackingOptions[T]) {
+	if opts.MaxLogsKept == 0 {
+		opts.MaxLogsKept = 1000
+	}
+	if opts.RetentionTime == 0 {
+		opts.RetentionTime = 86400
+	}
+	if opts.LogsPerBlock == 0 {
+		opts.LogsPerBlock = 100
+	}
+}
+
+func PrepareTopicArg(arg abi.Argument, value interface{}) (interface{}, error) {
+	t := reflect.TypeOf(value)
+
+	// only pre-hash:
+	//  - dynamic slices that aren't []byte
+	//  - fixed arrays that aren't [N]byte
+	//  - structs (i.e. tuple types)
+	if (t.Kind() == reflect.Slice && t.Elem().Kind() != reflect.Uint8) ||
+		(t.Kind() == reflect.Array && t.Elem().Kind() != reflect.Uint8) ||
+		t.Kind() == reflect.Struct {
+
+		packed, err := abi.Arguments{arg}.Pack(value)
+		if err != nil {
+			return nil, fmt.Errorf("packing %q for topic: %w", arg.Name, err)
+		}
+		// hash the packed bytes:
+		return crypto.Keccak256Hash(packed), nil
+	}
+
+	return value, nil
+}
+
+func PadTopics(topics []*evm.TopicValues) []*evm.TopicValues {
+	for i := len(topics); i < 4; i++ {
+		topics = append(topics, &evm.TopicValues{
+			Values: [][]byte{},
+		})
+	}
+
+	return topics
+}

--- a/capabilities/blockchain/evm/go.mod
+++ b/capabilities/blockchain/evm/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/capabilities/blockchain/evm/go.sum
+++ b/capabilities/blockchain/evm/go.sum
@@ -1,11 +1,17 @@
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/ethereum/go-ethereum v1.16.1 h1:7684NfKCb1+IChudzdKyZJ12l1Tq4ybPZOITiCDXqCk=
 github.com/ethereum/go-ethereum v1.16.1/go.mod h1:ngYIvmMAYdo4sGW9cGzLvSsPGhDOOzL0jK5S5iXpj0g=
 github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
 github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
 github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/cre/promise.go
+++ b/cre/promise.go
@@ -42,3 +42,14 @@ func Then[I, O any](p Promise[I], fn func(I) (O, error)) Promise[O] {
 		return fn(underlyingResult)
 	})
 }
+
+func ThenPromise[I, O any](p Promise[I], fn func(I) Promise[O]) Promise[O] {
+	return NewBasicPromise[O](func() (O, error) {
+		underlyingResult, err := p.Await()
+		if err != nil {
+			var o O
+			return o, err
+		}
+		return fn(underlyingResult).Await()
+	})
+}


### PR DESCRIPTION
PR 1/3 [cre-sdk-go](https://github.com/smartcontractkit/cre-sdk-go/pull/42)
PR 2/3 [chainlink-evm](https://github.com/smartcontractkit/chainlink-evm/pull/168)
PR 3/3 [dev-platforms](https://github.com/smartcontractkit/dev-platform/pull/553)