### PR TITLE
Use exit code zero with error return value in subscription, leaving non-zero for program failures.

### DIFF
--- a/cre/wasm/runner.go
+++ b/cre/wasm/runner.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
-	"os"
 	"unsafe"
 
 	"github.com/smartcontractkit/cre-sdk-go/cre"
@@ -22,29 +21,32 @@ type runnerInternals interface {
 	sendResponse(response unsafe.Pointer, responseLen int32) int32
 	versionV2()
 	switchModes(mode int32)
+	exit()
 }
 
 func newRunner[C Config](parse func(configBytes []byte) (C, error), runnerInternals runnerInternals, runtimeInternals runtimeInternals) cre.Runner[C] {
 	runnerInternals.versionV2()
 	runnerInternals.switchModes(int32(pb.Mode_MODE_DON))
 	drt := &sdkimpl.Runtime{RuntimeBase: newRuntime(runtimeInternals, pb.Mode_MODE_DON)}
-	return runnerWrapper[C]{baseRunner: getRunner(
-		parse,
-		&subscriber[C, cre.Runtime]{
-			sp:              drt,
-			runnerInternals: runnerInternals,
-			setRuntime: func(maxResponseSize uint64) {
-				drt.MaxResponseSize = maxResponseSize
+	return runnerWrapper[C]{
+		baseRunner: getRunner(
+			parse,
+			&subscriber[C, cre.Runtime]{
+				sp:              drt,
+				runnerInternals: runnerInternals,
+				setRuntime: func(maxResponseSize uint64) {
+					drt.MaxResponseSize = maxResponseSize
+				},
 			},
-		},
-		&runner[C, cre.Runtime]{
-			sp:              drt,
-			runtime:         drt,
-			runnerInternals: runnerInternals,
-			setRuntime: func(maxResponseSize uint64) {
-				drt.MaxResponseSize = maxResponseSize
-			},
-		}),
+			&runner[C, cre.Runtime]{
+				sp:              drt,
+				runtime:         drt,
+				runnerInternals: runnerInternals,
+				setRuntime: func(maxResponseSize uint64) {
+					drt.MaxResponseSize = maxResponseSize
+				},
+			}),
+		runnerInternals: runnerInternals,
 	}
 }
 
@@ -72,20 +74,16 @@ func (r *runner[C, T]) run(wfs []cre.ExecutionHandler[C, T]) {
 	for idx, handler := range wfs {
 		if uint64(idx) == r.trigger.Id {
 			response, err := handler.Callback()(r.config, r.runtime, r.trigger.Payload)
-			execResponse := &pb.ExecutionResult{}
 			if err == nil {
 				wrapped, err := values.Wrap(response)
 				if err != nil {
-					execResponse.Result = &pb.ExecutionResult_Error{Error: err.Error()}
+					exit(r.runnerInternals, &pb.ExecutionResult{Result: &pb.ExecutionResult_Error{Error: err.Error()}})
 				} else {
-					execResponse.Result = &pb.ExecutionResult_Value{Value: values.Proto(wrapped)}
+					exit(r.runnerInternals, &pb.ExecutionResult{Result: &pb.ExecutionResult_Value{Value: values.Proto(wrapped)}})
 				}
 			} else {
-				execResponse.Result = &pb.ExecutionResult_Error{Error: err.Error()}
+				exit(r.runnerInternals, &pb.ExecutionResult{Result: &pb.ExecutionResult_Error{Error: err.Error()}})
 			}
-			marshalled, _ := proto.Marshal(execResponse)
-			marshalledPtr, marshalledLen, _ := bufferToPointerLen(marshalled)
-			r.sendResponse(marshalledPtr, marshalledLen)
 		}
 	}
 }
@@ -123,19 +121,13 @@ func (s *subscriber[C, T]) run(wfs []cre.ExecutionHandler[C, T]) {
 		Result: &pb.ExecutionResult_TriggerSubscriptions{TriggerSubscriptions: triggerSubscription},
 	}
 
-	configBytes, _ := proto.Marshal(execResponse)
-	configPtr, configLen, _ := bufferToPointerLen(configBytes)
-
-	result := s.sendResponse(configPtr, configLen)
-	if result < 0 {
-		exitErr(fmt.Sprintf("could not subscribe to triggers: %s", string(configBytes[:-result])))
-	}
+	exit(s.runnerInternals, execResponse)
 }
 
-func getWorkflows[C any](config C, secretsProvider cre.SecretsProvider, initFn func(C, *slog.Logger, cre.SecretsProvider) (cre.Workflow[C], error)) cre.Workflow[C] {
+func (r runnerWrapper[C]) getWorkflows(config C, secretsProvider cre.SecretsProvider, initFn func(C, *slog.Logger, cre.SecretsProvider) (cre.Workflow[C], error)) cre.Workflow[C] {
 	wfs, err := initFn(config, newSlogger(), secretsProvider)
 	if err != nil {
-		exitErr(err.Error())
+		exitErr(r.runnerInternals, err.Error())
 	}
 	return wfs
 }
@@ -146,27 +138,27 @@ func getRunner[C, T any](parse func(configBytes []byte) (C, error), subscribe *s
 	// We expect exactly 2 args, i.e. `wasm <blob>`,
 	// where <blob> is a base64 encoded protobuf message.
 	if len(args) != 2 {
-		exitErr("invalid request: request must contain a payload")
+		exitErr(subscribe.runnerInternals, "invalid request: request must contain a payload")
 	}
 
 	request := args[1]
 	if request == "" {
-		exitErr("invalid request: request cannot be empty")
+		exitErr(subscribe.runnerInternals, "invalid request: request cannot be empty")
 	}
 
 	b, err := base64.StdEncoding.DecodeString(request)
 	if err != nil {
-		exitErr("invalid request: could not decode request into bytes")
+		exitErr(subscribe.runnerInternals, "invalid request: could not decode request into bytes")
 	}
 
 	execRequest := &pb.ExecuteRequest{}
 	if err = proto.Unmarshal(b, execRequest); err != nil {
-		exitErr("invalid request: could not unmarshal request into ExecuteRequest")
+		exitErr(subscribe.runnerInternals, "invalid request: could not unmarshal request into ExecuteRequest")
 	}
 
 	c, err := parse(execRequest.Config)
 	if err != nil {
-		exitErr(err.Error())
+		exitErr(subscribe.runnerInternals, err.Error())
 	}
 
 	switch req := execRequest.Request.(type) {
@@ -181,13 +173,19 @@ func getRunner[C, T any](parse func(configBytes []byte) (C, error), subscribe *s
 		return run
 	}
 
-	exitErr(fmt.Sprintf("invalid request: unknown request type %T", execRequest.Request))
+	exitErr(subscribe.runnerInternals, fmt.Sprintf("invalid request: unknown request type %T", execRequest.Request))
 	return nil
 }
 
-func exitErr(msg string) {
-	_, _ = (&writer{}).Write([]byte(msg))
-	os.Exit(1)
+func exitErr(r runnerInternals, err string) {
+	exit(r, &pb.ExecutionResult{Result: &pb.ExecutionResult_Error{Error: err}})
+}
+
+func exit(r runnerInternals, result *pb.ExecutionResult) {
+	marshalled, _ := proto.Marshal(result)
+	marshalledPtr, marshalledLen, _ := bufferToPointerLen(marshalled)
+	r.sendResponse(marshalledPtr, marshalledLen)
+	r.exit()
 }
 
 type baseRunner[C, T any] interface {
@@ -198,9 +196,10 @@ type baseRunner[C, T any] interface {
 
 type runnerWrapper[C any] struct {
 	baseRunner[C, cre.Runtime]
+	runnerInternals runnerInternals
 }
 
 func (r runnerWrapper[C]) Run(initFn func(config C, logger *slog.Logger, secretsProvider cre.SecretsProvider) (cre.Workflow[C], error)) {
-	wfs := getWorkflows(r.baseRunner.cfg(), r.secretsProvider(), initFn)
+	wfs := r.getWorkflows(r.baseRunner.cfg(), r.secretsProvider(), initFn)
 	r.baseRunner.run(wfs)
 }

--- a/cre/wasm/runner_test_hooks.go
+++ b/cre/wasm/runner_test_hooks.go
@@ -32,4 +32,8 @@ func (r *runnerInternalsTestHook) switchModes(mode int32) {
 	r.modeSwitched = true
 }
 
+func (r *runnerInternalsTestHook) exit() {
+	// Unlike the WASM, tests continue to execute
+}
+
 var _ runnerInternals = (*runnerInternalsTestHook)(nil)

--- a/cre/wasm/runner_wasip1.go
+++ b/cre/wasm/runner_wasip1.go
@@ -39,3 +39,7 @@ func (r runnerInternalsImpl) versionV2() {
 func (r runnerInternalsImpl) switchModes(mode int32) {
 	switchModes(mode)
 }
+
+func (r runnerInternalsImpl) exit() {
+	os.Exit(0)
+}


### PR DESCRIPTION
This lines up with how execution works already, and removes the junk in the local simulator