### PR TITLE
Typed capability errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ update-capabilities:
 
 # Override if you wish to test against a branch.
 # Alternatively, you can override the directory in chainlink-common to point to this repository
-COMMON_VERSION ?= cre-std-tests@0.6.0
+COMMON_VERSION ?= 7bfaef4bf1b347685884f9c16d30daaa3f9c5a6b
+#cre-std-tests@0.6.0
 MODULE := github.com/smartcontractkit/chainlink-common
 
 # Override on Windows if you aren't using a Unix-like shell:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ update-capabilities:
 
 # Override if you wish to test against a branch.
 # Alternatively, you can override the directory in chainlink-common to point to this repository
-COMMON_VERSION ?= 7bfaef4bf1b347685884f9c16d30daaa3f9c5a6b
+COMMON_VERSION ?= c5ae21941dc8122572fa2702afc5f9b23b2ce762
 #cre-std-tests@0.6.0
 MODULE := github.com/smartcontractkit/chainlink-common
 

--- a/capabilities/errors/error.go
+++ b/capabilities/errors/error.go
@@ -77,8 +77,6 @@ type Error interface {
 	Visibility() Visibility
 	Origin() Origin
 	Code() ErrorCode
-	SerializeToString() string
-	SerializeToRemoteString() string
 	Equals(otherErr Error) bool
 }
 

--- a/capabilities/errors/error.go
+++ b/capabilities/errors/error.go
@@ -77,7 +77,6 @@ type Error interface {
 	Visibility() Visibility
 	Origin() Origin
 	Code() ErrorCode
-	Equals(otherErr Error) bool
 }
 
 type capabilityError struct {
@@ -110,11 +109,4 @@ func (e capabilityError) Visibility() Visibility {
 
 func (e capabilityError) Code() ErrorCode {
 	return e.errorCode
-}
-
-func (e capabilityError) Equals(otherErr Error) bool {
-	return e.errorCode == otherErr.Code() &&
-		e.origin == otherErr.Origin() &&
-		e.visibility == otherErr.Visibility() &&
-		e.Error() == otherErr.Error()
 }

--- a/capabilities/errors/error.go
+++ b/capabilities/errors/error.go
@@ -96,6 +96,9 @@ func NewError(err error, visibility Visibility, origin Origin, errorCode ErrorCo
 }
 
 func (e capabilityError) Error() string {
+	if e.errorCode == UnrecognisedErrorCode {
+		return e.err.Error()
+	}
 	return fmt.Sprintf("[%d]%s: %s", e.errorCode, e.errorCode.String(), e.err.Error())
 }
 

--- a/capabilities/errors/error.go
+++ b/capabilities/errors/error.go
@@ -1,0 +1,150 @@
+// Package errors defines CRE capability errors and a wire format shared across CRE components.
+// It aligns with github.com/smartcontractkit/chainlink-common/pkg/capabilities/errors.
+package errors
+
+import "fmt"
+
+type Origin int
+
+const (
+	// OriginSystem The error originated from a system issue.
+	OriginSystem Origin = 0
+
+	// OriginUser The error originated from user input or action.
+	OriginUser Origin = 1
+)
+
+func (o Origin) String() string {
+	switch o {
+	case OriginSystem:
+		return "System"
+	case OriginUser:
+		return "User"
+	default:
+		return "Unknown"
+	}
+}
+
+// FromOriginString converts a string to an Origin value.
+func FromOriginString(s string) Origin {
+	switch s {
+	case "System":
+		return OriginSystem
+	case "User":
+		return OriginUser
+	default:
+		return Origin(-1)
+	}
+}
+
+type Visibility int
+
+const (
+	// VisibilityPublic The full details of the error can be shared across all nodes in the network.
+	VisibilityPublic Visibility = 0
+
+	// VisibilityPrivate The error contains sensitive information that should only be visible to the local node.
+	VisibilityPrivate Visibility = 1
+)
+
+// String returns the string representation of the Visibility value.
+func (v Visibility) String() string {
+	switch v {
+	case VisibilityPublic:
+		return "Public"
+	case VisibilityPrivate:
+		return "Private"
+	default:
+		return "Unknown"
+	}
+}
+
+// FromVisibilityString converts a string to a Visibility value.
+func FromVisibilityString(s string) Visibility {
+	switch s {
+	case "Public":
+		return VisibilityPublic
+	case "Private":
+		return VisibilityPrivate
+	default:
+		return Visibility(-1)
+	}
+}
+
+type Error interface {
+	error
+
+	Visibility() Visibility
+	Origin() Origin
+	Code() ErrorCode
+	SerializeToString() string
+	SerializeToRemoteString() string
+	Equals(otherErr Error) bool
+}
+
+type capabilityError struct {
+	err        error
+	origin     Origin
+	visibility Visibility
+	errorCode  ErrorCode
+}
+
+func NewError(err error, visibility Visibility, origin Origin, errorCode ErrorCode) Error {
+	return &capabilityError{
+		err:        err,
+		origin:     origin,
+		visibility: visibility,
+		errorCode:  errorCode,
+	}
+}
+
+// NewPublicSystemError indicates that the wrapped error is due to a system-level issue and does not contain any
+// sensitive information that should only be visible to the node on which it occurred, making it safe to share the full error details
+// with other nodes in the network.
+func NewPublicSystemError(err error, errorCode ErrorCode) Error {
+	return NewError(err, VisibilityPublic, OriginSystem, errorCode)
+}
+
+// NewPublicUserError indicates that the wrapped error is due to a user-level issue and does not contain any
+// information that should only be visible to the node on which it occurred, making it safe to share the full error details
+// with other nodes in the network.
+func NewPublicUserError(err error, errorCode ErrorCode) Error {
+	return NewError(err, VisibilityPublic, OriginUser, errorCode)
+}
+
+// NewPrivateSystemError indicates that the wrapped error is due to a system-level issue and may contain
+// sensitive information that should only be visible to the node on which it occurred.  The error code will still be
+// visible to other nodes in the network.
+func NewPrivateSystemError(err error, errorCode ErrorCode) Error {
+	return NewError(err, VisibilityPrivate, OriginSystem, errorCode)
+}
+
+// NewPrivateUserError indicates that the wrapped error is due to a user-level issue and may contain
+// sensitive information that should only be visible to the node on which it occurred.  The error code will still be
+// visible to other nodes in the network.
+func NewPrivateUserError(err error, errorCode ErrorCode) Error {
+	return NewError(err, VisibilityPrivate, OriginUser, errorCode)
+}
+
+func (e capabilityError) Error() string {
+	return fmt.Sprintf("[%d]%s: %s", e.errorCode, e.errorCode.String(), e.err.Error())
+}
+
+func (e capabilityError) Origin() Origin {
+	return e.origin
+}
+
+func (e capabilityError) Visibility() Visibility {
+	return e.visibility
+}
+
+func (e capabilityError) Code() ErrorCode {
+	return e.errorCode
+}
+
+func (e capabilityError) Equals(otherErr Error) bool {
+	return e.errorCode == otherErr.Code() &&
+		e.origin == otherErr.Origin() &&
+		e.visibility == otherErr.Visibility() &&
+		e.Error() == otherErr.Error()
+}

--- a/capabilities/errors/error.go
+++ b/capabilities/errors/error.go
@@ -98,34 +98,6 @@ func NewError(err error, visibility Visibility, origin Origin, errorCode ErrorCo
 	}
 }
 
-// NewPublicSystemError indicates that the wrapped error is due to a system-level issue and does not contain any
-// sensitive information that should only be visible to the node on which it occurred, making it safe to share the full error details
-// with other nodes in the network.
-func NewPublicSystemError(err error, errorCode ErrorCode) Error {
-	return NewError(err, VisibilityPublic, OriginSystem, errorCode)
-}
-
-// NewPublicUserError indicates that the wrapped error is due to a user-level issue and does not contain any
-// information that should only be visible to the node on which it occurred, making it safe to share the full error details
-// with other nodes in the network.
-func NewPublicUserError(err error, errorCode ErrorCode) Error {
-	return NewError(err, VisibilityPublic, OriginUser, errorCode)
-}
-
-// NewPrivateSystemError indicates that the wrapped error is due to a system-level issue and may contain
-// sensitive information that should only be visible to the node on which it occurred.  The error code will still be
-// visible to other nodes in the network.
-func NewPrivateSystemError(err error, errorCode ErrorCode) Error {
-	return NewError(err, VisibilityPrivate, OriginSystem, errorCode)
-}
-
-// NewPrivateUserError indicates that the wrapped error is due to a user-level issue and may contain
-// sensitive information that should only be visible to the node on which it occurred.  The error code will still be
-// visible to other nodes in the network.
-func NewPrivateUserError(err error, errorCode ErrorCode) Error {
-	return NewError(err, VisibilityPrivate, OriginUser, errorCode)
-}
-
 func (e capabilityError) Error() string {
 	return fmt.Sprintf("[%d]%s: %s", e.errorCode, e.errorCode.String(), e.err.Error())
 }

--- a/capabilities/errors/error.go
+++ b/capabilities/errors/error.go
@@ -21,7 +21,7 @@ func (o Origin) String() string {
 	case OriginUser:
 		return "User"
 	default:
-		return "Unknown"
+		return "UnknownOrigin"
 	}
 }
 
@@ -55,7 +55,7 @@ func (v Visibility) String() string {
 	case VisibilityPrivate:
 		return "Private"
 	default:
-		return "Unknown"
+		return "UnknownVisibility"
 	}
 }
 

--- a/capabilities/errors/error_codes.go
+++ b/capabilities/errors/error_codes.go
@@ -183,10 +183,3 @@ func FromErrorCodeString(str string) ErrorCode {
 	}
 	return Unknown
 }
-
-// IsKnownErrorCodeString reports whether s is a registered ErrorCode name (the
-// inverse of FromErrorCodeString defaulting unknown strings to Unknown).
-func IsKnownErrorCodeString(s string) bool {
-	_, ok := stringToErrorCode[s]
-	return ok
-}

--- a/capabilities/errors/error_codes.go
+++ b/capabilities/errors/error_codes.go
@@ -130,6 +130,12 @@ const (
 
 	// ConsensusFailed indicates failure to reach consensus
 	ConsensusFailed ErrorCode = 100
+
+	// LimitExceeded indicates that a CRE limit breach has occurred.
+	LimitExceeded ErrorCode = 101
+
+	// InsufficientObservations indicates that there are not enough observations to enable the operation to complete.
+	InsufficientObservations ErrorCode = 102
 )
 
 // String returns the string representation of the ErrorCode.
@@ -157,7 +163,9 @@ var errorCodeToString = map[ErrorCode]string{
 	Unavailable:        "Unavailable",
 	DataLoss:           "DataLoss",
 	Unauthenticated:    "Unauthenticated",
-	ConsensusFailed:    "ConsensusFailed",
+	ConsensusFailed:          "ConsensusFailed",
+	LimitExceeded:            "LimitExceeded",
+	InsufficientObservations: "InsufficientObservations",
 }
 
 var stringToErrorCode = map[string]ErrorCode{
@@ -177,7 +185,9 @@ var stringToErrorCode = map[string]ErrorCode{
 	"Unavailable":        Unavailable,
 	"DataLoss":           DataLoss,
 	"Unauthenticated":    Unauthenticated,
-	"ConsensusFailed":    ConsensusFailed,
+	"ConsensusFailed":          ConsensusFailed,
+	"LimitExceeded":            LimitExceeded,
+	"InsufficientObservations": InsufficientObservations,
 }
 
 func FromErrorCodeString(str string) ErrorCode {

--- a/capabilities/errors/error_codes.go
+++ b/capabilities/errors/error_codes.go
@@ -8,6 +8,9 @@ type ErrorCode int
 // conflicts with future gRPC codes. Note: 0 (OK) is intentionally excluded
 // because capability errors must always indicate a failure condition.
 const (
+	// UnrecognisedErrorCode is the sentinel for error code strings that are not recognised.
+	UnrecognisedErrorCode ErrorCode = -1
+
 	// Canceled indicates the operation was canceled (typically by the caller).
 	Canceled ErrorCode = 1
 
@@ -134,7 +137,7 @@ func (e ErrorCode) String() string {
 	if s, ok := errorCodeToString[e]; ok {
 		return s
 	}
-	return "UnknownErrorCode"
+	return "UnrecognisedErrorCode"
 }
 
 var errorCodeToString = map[ErrorCode]string{
@@ -181,5 +184,5 @@ func FromErrorCodeString(str string) ErrorCode {
 	if code, ok := stringToErrorCode[str]; ok {
 		return code
 	}
-	return ErrorCode(-1)
+	return UnrecognisedErrorCode
 }

--- a/capabilities/errors/error_codes.go
+++ b/capabilities/errors/error_codes.go
@@ -1,7 +1,5 @@
 package errors
 
-import "fmt"
-
 type ErrorCode int
 
 // Capability error codes are primarily based on gRPC error codes:
@@ -136,7 +134,7 @@ func (e ErrorCode) String() string {
 	if s, ok := errorCodeToString[e]; ok {
 		return s
 	}
-	return fmt.Sprintf("UnknownErrorCode[%d]", e)
+	return "UnknownErrorCode"
 }
 
 var errorCodeToString = map[ErrorCode]string{

--- a/capabilities/errors/error_codes.go
+++ b/capabilities/errors/error_codes.go
@@ -1,0 +1,192 @@
+package errors
+
+type ErrorCode uint32
+
+// Capability error codes are primarily based on gRPC error codes:
+// https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+// Custom error codes specific to this project should start from 100 to avoid
+// conflicts with future gRPC codes. Note: 0 (OK) is intentionally excluded
+// because capability errors must always indicate a failure condition.
+const (
+	// Canceled indicates the operation was canceled (typically by the caller).
+	Canceled ErrorCode = 1
+
+	// Unknown error. An example of where this error may be returned is
+	// if a Status value received from another address space belongs to
+	// an error-space that is not known in this address space. Also
+	// errors raised by APIs that do not return enough error information
+	// may be converted to this error.
+	Unknown ErrorCode = 2
+
+	// InvalidArgument indicates client specified an invalid argument.
+	// Note that this differs from FailedPrecondition. It indicates arguments
+	// that are problematic regardless of the state of the system
+	// (e.g., a malformed file name).
+	InvalidArgument ErrorCode = 3
+
+	// DeadlineExceeded means operation expired before completion.
+	// For operations that change the state of the system, this error may be
+	// returned even if the operation has completed successfully. For
+	// example, a successful response from a server could have been delayed
+	// long enough for the deadline to expire.
+	DeadlineExceeded ErrorCode = 4
+
+	// NotFound means some requested entity (e.g., file or directory) was
+	// not found.
+	NotFound ErrorCode = 5
+
+	// AlreadyExists means an attempt to create an entity failed because one
+	// already exists.
+	AlreadyExists ErrorCode = 6
+
+	// PermissionDenied indicates the caller does not have permission to
+	// execute the specified operation. It must not be used for rejections
+	// caused by exhausting some resource (use ResourceExhausted
+	// instead for those errors). It must not be
+	// used if the caller cannot be identified (use Unauthenticated
+	// instead for those errors).
+	PermissionDenied ErrorCode = 7
+
+	// ResourceExhausted indicates some resource has been exhausted, perhaps
+	// a per-user quota, or perhaps the entire file system is out of space.
+	ResourceExhausted ErrorCode = 8
+
+	// FailedPrecondition indicates operation was rejected because the
+	// system is not in a state required for the operation's execution.
+	// For example, directory to be deleted may be non-empty, an rmdir
+	// operation is applied to a non-directory, etc.
+	//
+	// A litmus test that may help a service implementor in deciding
+	// between FailedPrecondition, Aborted, and Unavailable:
+	//  (a) Use Unavailable if the client can retry just the failing call.
+	//  (b) Use Aborted if the client should retry at a higher-level
+	//      (e.g., restarting a read-modify-write sequence).
+	//  (c) Use FailedPrecondition if the client should not retry until
+	//      the system state has been explicitly fixed. E.g., if an "rmdir"
+	//      fails because the directory is non-empty, FailedPrecondition
+	//      should be returned since the client should not retry unless
+	//      they have first fixed up the directory by deleting files from it.
+	//  (d) Use FailedPrecondition if the client performs conditional
+	//      REST Get/Update/Delete on a resource and the resource on the
+	//      server does not match the condition. E.g., conflicting
+	//      read-modify-write on the same resource.
+	FailedPrecondition ErrorCode = 9
+
+	// Aborted indicates the operation was aborted, typically due to a
+	// concurrency issue like sequencer check failures, transaction aborts,
+	// etc.
+	//
+	// See litmus test above for deciding between FailedPrecondition,
+	// Aborted, and Unavailable.
+	Aborted ErrorCode = 10
+
+	// OutOfRange means operation was attempted past the valid range.
+	// E.g., seeking or reading past end of file.
+	//
+	// Unlike InvalidArgument, this error indicates a problem that may
+	// be fixed if the system state changes. For example, a 32-bit file
+	// system will generate InvalidArgument if asked to read at an
+	// offset that is not in the range [0,2^32-1], but it will generate
+	// OutOfRange if asked to read from an offset past the current
+	// file size.
+	//
+	// There is a fair bit of overlap between FailedPrecondition and
+	// OutOfRange. We recommend using OutOfRange (the more specific
+	// error) when it applies so that callers who are iterating through
+	// a space can easily look for an OutOfRange error to detect when
+	// they are done.
+	OutOfRange ErrorCode = 11
+
+	// Unimplemented indicates operation is not implemented or not
+	// supported/enabled in this service.
+	Unimplemented ErrorCode = 12
+
+	// Internal errors. Means some invariants expected by underlying
+	// system has been broken. If you see one of these errors,
+	// something is very broken.
+	Internal ErrorCode = 13
+
+	// Unavailable indicates the service is currently unavailable.
+	// This is a most likely a transient condition and may be corrected
+	// by retrying with a backoff. Note that it is not always safe to retry
+	// non-idempotent operations.
+	//
+	// See litmus test above for deciding between FailedPrecondition,
+	// Aborted, and Unavailable.
+	Unavailable ErrorCode = 14
+
+	// DataLoss indicates unrecoverable data loss or corruption.
+	DataLoss ErrorCode = 15
+
+	// Unauthenticated indicates the request does not have valid
+	// authentication credentials for the operation.
+	Unauthenticated ErrorCode = 16
+
+	// Custom error codes not defined in the gRPC error space are defined below this point,
+	// starting at 100 to avoid collision with future gRPC defined codes.
+
+	// ConsensusFailed indicates failure to reach consensus
+	ConsensusFailed ErrorCode = 100
+)
+
+// String returns the string representation of the ErrorCode.
+func (e ErrorCode) String() string {
+	if s, ok := errorCodeToString[e]; ok {
+		return s
+	}
+	return "Unknown"
+}
+
+var errorCodeToString = map[ErrorCode]string{
+	Canceled:           "Canceled",
+	Unknown:            "Unknown",
+	InvalidArgument:    "InvalidArgument",
+	DeadlineExceeded:   "DeadlineExceeded",
+	NotFound:           "NotFound",
+	AlreadyExists:      "AlreadyExists",
+	PermissionDenied:   "PermissionDenied",
+	ResourceExhausted:  "ResourceExhausted",
+	FailedPrecondition: "FailedPrecondition",
+	Aborted:            "Aborted",
+	OutOfRange:         "OutOfRange",
+	Unimplemented:      "Unimplemented",
+	Internal:           "Internal",
+	Unavailable:        "Unavailable",
+	DataLoss:           "DataLoss",
+	Unauthenticated:    "Unauthenticated",
+	ConsensusFailed:    "ConsensusFailed",
+}
+
+var stringToErrorCode = map[string]ErrorCode{
+	"Canceled":           Canceled,
+	"Unknown":            Unknown,
+	"InvalidArgument":    InvalidArgument,
+	"DeadlineExceeded":   DeadlineExceeded,
+	"NotFound":           NotFound,
+	"AlreadyExists":      AlreadyExists,
+	"PermissionDenied":   PermissionDenied,
+	"ResourceExhausted":  ResourceExhausted,
+	"FailedPrecondition": FailedPrecondition,
+	"Aborted":            Aborted,
+	"OutOfRange":         OutOfRange,
+	"Unimplemented":      Unimplemented,
+	"Internal":           Internal,
+	"Unavailable":        Unavailable,
+	"DataLoss":           DataLoss,
+	"Unauthenticated":    Unauthenticated,
+	"ConsensusFailed":    ConsensusFailed,
+}
+
+func FromErrorCodeString(str string) ErrorCode {
+	if code, ok := stringToErrorCode[str]; ok {
+		return code
+	}
+	return Unknown
+}
+
+// IsKnownErrorCodeString reports whether s is a registered ErrorCode name (the
+// inverse of FromErrorCodeString defaulting unknown strings to Unknown).
+func IsKnownErrorCodeString(s string) bool {
+	_, ok := stringToErrorCode[s]
+	return ok
+}

--- a/capabilities/errors/error_codes.go
+++ b/capabilities/errors/error_codes.go
@@ -1,6 +1,8 @@
 package errors
 
-type ErrorCode uint32
+import "fmt"
+
+type ErrorCode int
 
 // Capability error codes are primarily based on gRPC error codes:
 // https://grpc.github.io/grpc/core/md_doc_statuscodes.html
@@ -134,7 +136,7 @@ func (e ErrorCode) String() string {
 	if s, ok := errorCodeToString[e]; ok {
 		return s
 	}
-	return "Unknown"
+	return fmt.Sprintf("UnknownErrorCode[%d]", e)
 }
 
 var errorCodeToString = map[ErrorCode]string{
@@ -181,5 +183,5 @@ func FromErrorCodeString(str string) ErrorCode {
 	if code, ok := stringToErrorCode[str]; ok {
 		return code
 	}
-	return Unknown
+	return ErrorCode(-1)
 }

--- a/capabilities/errors/error_serialization.go
+++ b/capabilities/errors/error_serialization.go
@@ -53,21 +53,3 @@ func DeserializeErrorFromString(errorMsg string, wrapUndeserializableAsCapabilit
 
 	return NewError(errors.New(detail), visibility, origin, errorCode)
 }
-
-func (e capabilityError) SerializeToString() string {
-	return e.serializeToString(e.err.Error())
-}
-
-func (e capabilityError) serializeToString(errMsg string) string {
-	return e.visibility.String() + errorMessageSeparator + e.origin.String() + errorMessageSeparator + e.Code().String() + errorMessageSeparator + errMsg
-}
-
-// SerializeToRemoteString serializes the error for sending to remote nodes.
-// If the error is private, the actual error message is replaced with a generic message.
-func (e capabilityError) SerializeToRemoteString() string {
-	if e.Visibility() == VisibilityPublic {
-		return e.serializeToString(e.err.Error())
-	}
-
-	return e.serializeToString("error whilst executing capability - the error message is not publicly reportable")
-}

--- a/capabilities/errors/error_serialization.go
+++ b/capabilities/errors/error_serialization.go
@@ -7,33 +7,12 @@ import (
 
 const errorMessageSeparator = ":"
 
-func serializedCapabilityErrorMetadataValid(visibility, origin, errorCode string) bool {
-	switch FromVisibilityString(visibility) {
-	case VisibilityPublic, VisibilityPrivate:
-	default:
-		return false
-	}
-	switch FromOriginString(origin) {
-	case OriginSystem, OriginUser:
-	default:
-		return false
-	}
-	return IsKnownErrorCodeString(errorCode)
-}
-
 // DeserializeErrorFromString parses errorMsg in the capability error wire format.
-// If errorMsg is not a serialized capability error, behavior depends on wrapUndeserializableAsCapabilityError:
-// when true, the full string is wrapped as a private system error with code Unknown (backwards compatible with
-// older nodes); when false, errors.New(errorMsg) is returned and the result is not a capability Error.
-func DeserializeErrorFromString(errorMsg string, wrapUndeserializableAsCapabilityError bool) error {
+// If errorMsg is not a serialized capability error errors.New(errorMsg) is returned and the result is not a capability Error.
+func DeserializeErrorFromString(errorMsg string) error {
 	parts := strings.SplitN(errorMsg, errorMessageSeparator, 4)
 
-	if len(parts) < 4 || !serializedCapabilityErrorMetadataValid(parts[0], parts[1], parts[2]) {
-		if wrapUndeserializableAsCapabilityError {
-			// To maintain backwards compatibility with messages from remote nodes on an older code version, create an error
-			// with the full message and default to private system error with an unknown error code.
-			return NewError(errors.New(errorMsg), VisibilityPrivate, OriginSystem, Unknown)
-		}
+	if len(parts) < 4 {
 		return errors.New(errorMsg)
 	}
 

--- a/capabilities/errors/error_serialization.go
+++ b/capabilities/errors/error_serialization.go
@@ -7,10 +7,6 @@ import (
 
 const errorMessageSeparator = ":"
 
-func PrePendPrivateVisibilityIdentifier(errorMessage string) string {
-	return VisibilityPrivate.String() + errorMessageSeparator + errorMessage
-}
-
 // IsSerializedCapabilityErrorString reports whether s uses the capability error
 // wire format (Visibility:Origin:ErrorCode:detail) with known enum/code names.
 // Arbitrary text that happens to contain three colons is not treated as

--- a/capabilities/errors/error_serialization.go
+++ b/capabilities/errors/error_serialization.go
@@ -1,0 +1,77 @@
+package errors
+
+import (
+	"errors"
+	"strings"
+)
+
+const errorMessageSeparator = ":"
+
+func PrePendPrivateVisibilityIdentifier(errorMessage string) string {
+	return VisibilityPrivate.String() + errorMessageSeparator + errorMessage
+}
+
+// IsSerializedCapabilityErrorString reports whether s uses the capability error
+// wire format (Visibility:Origin:ErrorCode:detail) with known enum/code names.
+// Arbitrary text that happens to contain three colons is not treated as
+// serialized unless the first three segments are valid.
+func IsSerializedCapabilityErrorString(s string) bool {
+	parts := strings.SplitN(s, errorMessageSeparator, 4)
+	return len(parts) == 4 && serializedCapabilityErrorMetadataValid(parts[0], parts[1], parts[2])
+}
+
+func serializedCapabilityErrorMetadataValid(visibility, origin, errorCode string) bool {
+	switch FromVisibilityString(visibility) {
+	case VisibilityPublic, VisibilityPrivate:
+	default:
+		return false
+	}
+	switch FromOriginString(origin) {
+	case OriginSystem, OriginUser:
+	default:
+		return false
+	}
+	return IsKnownErrorCodeString(errorCode)
+}
+
+// DeserializeErrorFromString parses errorMsg in the capability error wire format.
+// If errorMsg is not a serialized capability error, behavior depends on wrapUndeserializableAsCapabilityError:
+// when true, the full string is wrapped as a private system error with code Unknown (backwards compatible with
+// older nodes); when false, errors.New(errorMsg) is returned and the result is not a capability Error.
+func DeserializeErrorFromString(errorMsg string, wrapUndeserializableAsCapabilityError bool) error {
+	parts := strings.SplitN(errorMsg, errorMessageSeparator, 4)
+
+	if len(parts) < 4 || !serializedCapabilityErrorMetadataValid(parts[0], parts[1], parts[2]) {
+		if wrapUndeserializableAsCapabilityError {
+			// To maintain backwards compatibility with messages from remote nodes on an older code version, create an error
+			// with the full message and default to private system error with an unknown error code.
+			return NewError(errors.New(errorMsg), VisibilityPrivate, OriginSystem, Unknown)
+		}
+		return errors.New(errorMsg)
+	}
+
+	visibility := FromVisibilityString(parts[0])
+	origin := FromOriginString(parts[1])
+	errorCode := FromErrorCodeString(parts[2])
+	detail := parts[3]
+
+	return NewError(errors.New(detail), visibility, origin, errorCode)
+}
+
+func (e capabilityError) SerializeToString() string {
+	return e.serializeToString(e.err.Error())
+}
+
+func (e capabilityError) serializeToString(errMsg string) string {
+	return e.visibility.String() + errorMessageSeparator + e.origin.String() + errorMessageSeparator + e.Code().String() + errorMessageSeparator + errMsg
+}
+
+// SerializeToRemoteString serializes the error for sending to remote nodes.
+// If the error is private, the actual error message is replaced with a generic message.
+func (e capabilityError) SerializeToRemoteString() string {
+	if e.Visibility() == VisibilityPublic {
+		return e.serializeToString(e.err.Error())
+	}
+
+	return e.serializeToString("error whilst executing capability - the error message is not publicly reportable")
+}

--- a/capabilities/errors/error_serialization.go
+++ b/capabilities/errors/error_serialization.go
@@ -7,15 +7,6 @@ import (
 
 const errorMessageSeparator = ":"
 
-// IsSerializedCapabilityErrorString reports whether s uses the capability error
-// wire format (Visibility:Origin:ErrorCode:detail) with known enum/code names.
-// Arbitrary text that happens to contain three colons is not treated as
-// serialized unless the first three segments are valid.
-func IsSerializedCapabilityErrorString(s string) bool {
-	parts := strings.SplitN(s, errorMessageSeparator, 4)
-	return len(parts) == 4 && serializedCapabilityErrorMetadataValid(parts[0], parts[1], parts[2])
-}
-
 func serializedCapabilityErrorMetadataValid(visibility, origin, errorCode string) bool {
 	switch FromVisibilityString(visibility) {
 	case VisibilityPublic, VisibilityPrivate:

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -50,7 +50,7 @@ func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.VisibilityPublic, caperrs.OriginSystem, caperrs.UnrecognisedErrorCode)
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 		require.Equal(t, "UnrecognisedErrorCode", deserializedErr.Code().String())
-		require.Equal(t, "[-1]UnrecognisedErrorCode: some error occurred", deserializedErr.Error())
+		require.Equal(t, "some error occurred", deserializedErr.Error())
 	})
 
 	t.Run("ColonRichPlainMessageMatchingUnknownCode", func(t *testing.T) {

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -23,60 +23,56 @@ func capabilityErrorsEqual(a, b caperrs.Error) bool {
 		a.Error() == b.Error()
 }
 
-func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibility(t *testing.T) {
+// TestDeserializeErrorFromStringInvalidFields verifies that DeserializeErrorFromString can handle invalid visibility,
+// origin, and error code fields gracefully, defaulting to "Unknown" for unrecognized tokens and still returning a
+// capability error when the format is correct.  This ensures backwards compatibility for any new values introduced
+// in the future.
+func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 	t.Run("InvalidVisibility", func(t *testing.T) {
 		serializedError := "InvalidVisibility:User:Unknown:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
-		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
-			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
-		}
+		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.Visibility(-1), caperrs.OriginUser, caperrs.Unknown)
+		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 	})
 
 	t.Run("InvalidOrigin", func(t *testing.T) {
 		serializedError := "Public:InvalidOrigin:Unknown:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
-		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
-			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
-		}
+		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.VisibilityPublic, caperrs.Origin(-1), caperrs.Unknown)
+		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 	})
 
 	t.Run("InvalidErrorCode", func(t *testing.T) {
 		serializedError := "Public:System:InvalidErrorCode:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
-		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
-			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
-		}
-	})
-
-	t.Run("InvalidMessageInsufficientFields", func(t *testing.T) {
-		msg := "Public:System:Unknown"
-		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg))
-
-		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
-			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
-		}
-	})
-
-	t.Run("NotASerializedCapabilityError", func(t *testing.T) {
-		msg := "some error has occurred that is not in the serialized capability error format"
-		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg))
-
-		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
-			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
-		}
+		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.VisibilityPublic, caperrs.OriginSystem, caperrs.Unknown)
+		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 	})
 
 	t.Run("ColonRichPlainMessageMatchingUnknownCode", func(t *testing.T) {
-		// Four segments with a known error code token but invalid visibility — legacy wrap.
+		// Four segments are always parsed as wire format; invalid visibility/origin tokens are preserved.
 		msg := "failed: attempt: Unknown: details here"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg))
-		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
+		expectedErr := caperrs.NewError(stderrors.New(" details here"), caperrs.Visibility(-1), caperrs.Origin(-1), caperrs.Unknown)
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
+	})
+}
+
+func TestDeserializeErrorFromStringNonWireFormat(t *testing.T) {
+	t.Run("InsufficientFields", func(t *testing.T) {
+		msg := "Public:System:Unknown"
+		err := caperrs.DeserializeErrorFromString(msg)
+		require.Equal(t, msg, err.Error())
+		_, ok := err.(caperrs.Error)
+		require.False(t, ok)
+	})
+
+	t.Run("PlainMessage", func(t *testing.T) {
+		msg := "some error has occurred that is not in the serialized capability error format"
+		err := caperrs.DeserializeErrorFromString(msg)
+		require.Equal(t, msg, err.Error())
+		_, ok := err.(caperrs.Error)
+		require.False(t, ok)
 	})
 }
 

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -23,20 +23,10 @@ func capabilityErrorsEqual(a, b caperrs.Error) bool {
 		a.Error() == b.Error()
 }
 
-func TestParsingOldErrorFormat(t *testing.T) {
-	oldErrorMsgString := "failed to execute capability: some error occurred"
-	deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(oldErrorMsgString, true))
-
-	expectedErr := caperrs.NewError(stderrors.New(oldErrorMsgString), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-	if !capabilityErrorsEqual(deserializedErr, expectedErr) {
-		t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
-	}
-}
-
 func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibility(t *testing.T) {
 	t.Run("InvalidVisibility", func(t *testing.T) {
 		serializedError := "InvalidVisibility:User:Unknown:some error occurred"
-		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
 		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
@@ -45,7 +35,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 
 	t.Run("InvalidOrigin", func(t *testing.T) {
 		serializedError := "Public:InvalidOrigin:Unknown:some error occurred"
-		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
 		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
@@ -54,7 +44,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 
 	t.Run("InvalidErrorCode", func(t *testing.T) {
 		serializedError := "Public:System:InvalidErrorCode:some error occurred"
-		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
 		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
@@ -63,7 +53,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 
 	t.Run("InvalidMessageInsufficientFields", func(t *testing.T) {
 		msg := "Public:System:Unknown"
-		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg))
 
 		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
@@ -73,7 +63,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 
 	t.Run("NotASerializedCapabilityError", func(t *testing.T) {
 		msg := "some error has occurred that is not in the serialized capability error format"
-		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg))
 
 		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
@@ -84,16 +74,16 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 	t.Run("ColonRichPlainMessageMatchingUnknownCode", func(t *testing.T) {
 		// Four segments with a known error code token but invalid visibility — legacy wrap.
 		msg := "failed: attempt: Unknown: details here"
-		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg))
 		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 	})
 }
 
-func TestDeserializeErrorFromString_withoutCapabilityWrap(t *testing.T) {
+func TestDeserializeErrorFromStringThatIsNotSerialisedCapabilityError(t *testing.T) {
 	t.Run("plain message returns stdlib error", func(t *testing.T) {
 		msg := "some plain failure"
-		err := caperrs.DeserializeErrorFromString(msg, false)
+		err := caperrs.DeserializeErrorFromString(msg)
 		require.Equal(t, msg, err.Error())
 		_, ok := err.(caperrs.Error)
 		require.False(t, ok)
@@ -102,7 +92,7 @@ func TestDeserializeErrorFromString_withoutCapabilityWrap(t *testing.T) {
 	t.Run("valid serialized still returns capability error", func(t *testing.T) {
 		serialized := "Public:User:DeadlineExceeded:detail"
 		expected := caperrs.NewError(stderrors.New("detail"), caperrs.VisibilityPublic, caperrs.OriginUser, caperrs.DeadlineExceeded)
-		err := caperrs.DeserializeErrorFromString(serialized, false)
+		err := caperrs.DeserializeErrorFromString(serialized)
 		deserialized := requireCapabilityError(t, err)
 		require.True(t, capabilityErrorsEqual(expected, deserialized))
 	})

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -24,9 +24,9 @@ func capabilityErrorsEqual(a, b caperrs.Error) bool {
 }
 
 // TestDeserializeErrorFromStringInvalidFields verifies that DeserializeErrorFromString can handle invalid visibility,
-// origin, and error code fields gracefully, defaulting to "Unknown" for unrecognized tokens and still returning a
-// capability error when the format is correct.  This ensures backwards compatibility for any new values introduced
-// in the future.
+// origin, and error code fields gracefully, preserving unrecognized tokens as typed sentinel values (-1) and still
+// returning a capability error when the format is correct. This ensures backwards compatibility for any new values
+// introduced in the future.
 func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 	t.Run("InvalidVisibility", func(t *testing.T) {
 		serializedError := "InvalidVisibility:User:Unknown:some error occurred"
@@ -42,16 +42,16 @@ func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 	})
 
-	t.Run("InvalidErrorCode", func(t *testing.T) {
-		serializedError := "Public:System:InvalidErrorCode:some error occurred"
+	t.Run("NewUnknownErrorCode", func(t *testing.T) {
+		serializedError := "Public:System:NewUnknownErrorCode:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
-		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.VisibilityPublic, caperrs.OriginSystem, caperrs.Unknown)
+		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.VisibilityPublic, caperrs.OriginSystem, caperrs.ErrorCode(-1))
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 	})
 
 	t.Run("ColonRichPlainMessageMatchingUnknownCode", func(t *testing.T) {
 		// Four segments are always parsed as wire format; invalid visibility/origin tokens are preserved.
-		msg := "failed: attempt: Unknown: details here"
+		msg := "failed:attempt:Unknown: details here"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg))
 		expectedErr := caperrs.NewError(stderrors.New(" details here"), caperrs.Visibility(-1), caperrs.Origin(-1), caperrs.Unknown)
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -44,13 +44,13 @@ func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 		require.Equal(t, "UnknownOrigin", deserializedErr.Origin().String())
 	})
 
-	t.Run("NewUnknownErrorCode", func(t *testing.T) {
+	t.Run("UnrecognisedErrorCode", func(t *testing.T) {
 		serializedError := "Public:System:NewUnknownErrorCode:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
-		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.VisibilityPublic, caperrs.OriginSystem, caperrs.ErrorCode(-1))
+		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.VisibilityPublic, caperrs.OriginSystem, caperrs.UnrecognisedErrorCode)
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
-		require.Equal(t, "UnknownErrorCode", deserializedErr.Code().String())
-		require.Equal(t, "[-1]UnknownErrorCode: some error occurred", deserializedErr.Error())
+		require.Equal(t, "UnrecognisedErrorCode", deserializedErr.Code().String())
+		require.Equal(t, "[-1]UnrecognisedErrorCode: some error occurred", deserializedErr.Error())
 	})
 
 	t.Run("ColonRichPlainMessageMatchingUnknownCode", func(t *testing.T) {
@@ -60,15 +60,6 @@ func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 		expectedErr := caperrs.NewError(stderrors.New(" details here"), caperrs.Visibility(-1), caperrs.Origin(-1), caperrs.Unknown)
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 	})
-}
-
-func TestUnknownValueStringOutput(t *testing.T) {
-	require.Equal(t, "UnknownOrigin", caperrs.Origin(-1).String())
-	require.Equal(t, "UnknownVisibility", caperrs.Visibility(-1).String())
-	require.Equal(t, "UnknownErrorCode", caperrs.ErrorCode(-1).String())
-
-	err := caperrs.NewError(stderrors.New("detail"), caperrs.Visibility(-1), caperrs.Origin(-1), caperrs.ErrorCode(-1))
-	require.Equal(t, "[-1]UnknownErrorCode: detail", err.Error())
 }
 
 func TestDeserializeErrorFromStringNonWireFormat(t *testing.T) {

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -2,7 +2,6 @@ package errors_test
 
 import (
 	stderrors "errors"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,51 +14,6 @@ func requireCapabilityError(tb testing.TB, err error) caperrs.Error {
 	ce, ok := err.(caperrs.Error)
 	require.True(tb, ok, "expected capability errors.Error, got %T", err)
 	return ce
-}
-
-func TestErrorSerializationAndDeserialization(t *testing.T) {
-	visibilities := []caperrs.Visibility{caperrs.VisibilityPublic, caperrs.VisibilityPrivate}
-	origins := []caperrs.Origin{caperrs.OriginUser, caperrs.OriginSystem}
-	errorCodes := []caperrs.ErrorCode{caperrs.Unknown, caperrs.ConsensusFailed, caperrs.InvalidArgument}
-
-	for _, v := range visibilities {
-		for _, o := range origins {
-			for _, c := range errorCodes {
-				originalErr := caperrs.NewError(stderrors.New("test error"), v, o, c)
-				serialized := originalErr.SerializeToString()
-				deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serialized, true))
-				if !originalErr.Equals(deserializedErr) {
-					t.Errorf("expected %v, got %v", originalErr, deserializedErr)
-				}
-			}
-		}
-	}
-}
-
-func TestRemoteErrorSerializationAndDeserialization(t *testing.T) {
-	visibilities := []caperrs.Visibility{caperrs.VisibilityPublic, caperrs.VisibilityPrivate}
-	origins := []caperrs.Origin{caperrs.OriginUser, caperrs.OriginSystem}
-	errorCodes := []caperrs.ErrorCode{caperrs.Unknown, caperrs.ConsensusFailed, caperrs.InvalidArgument}
-
-	for _, v := range visibilities {
-		for _, o := range origins {
-			for _, c := range errorCodes {
-				originalErr := caperrs.NewError(stderrors.New("test error"), v, o, c)
-				serialized := originalErr.SerializeToRemoteString()
-				deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serialized, true))
-				if v == caperrs.VisibilityPrivate {
-					require.Equal(t, deserializedErr.Visibility(), originalErr.Visibility())
-					require.Equal(t, deserializedErr.Origin(), originalErr.Origin())
-					require.Equal(t, deserializedErr.Code(), originalErr.Code())
-					require.True(t, strings.Contains(deserializedErr.Error(), "error whilst executing capability - the error message is not publicly reportable"))
-				} else {
-					if !originalErr.Equals(deserializedErr) {
-						t.Errorf("expected %v, got %v", originalErr, deserializedErr)
-					}
-				}
-			}
-		}
-	}
 }
 
 func TestParsingOldErrorFormat(t *testing.T) {
@@ -134,8 +88,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 }
 
 func TestIsSerializedCapabilityErrorString(t *testing.T) {
-	valid := caperrs.NewError(stderrors.New("detail"), caperrs.VisibilityPublic, caperrs.OriginSystem, caperrs.InvalidArgument).SerializeToString()
-	require.True(t, caperrs.IsSerializedCapabilityErrorString(valid))
+	require.True(t, caperrs.IsSerializedCapabilityErrorString("Public:System:InvalidArgument:detail"))
 
 	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:System"))
 	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:System:Unknown"))
@@ -157,10 +110,10 @@ func TestDeserializeErrorFromString_withoutCapabilityWrap(t *testing.T) {
 	})
 
 	t.Run("valid serialized still returns capability error", func(t *testing.T) {
-		original := caperrs.NewError(stderrors.New("detail"), caperrs.VisibilityPublic, caperrs.OriginUser, caperrs.DeadlineExceeded)
-		serialized := original.SerializeToString()
+		serialized := "Public:User:DeadlineExceeded:detail"
+		expected := caperrs.NewError(stderrors.New("detail"), caperrs.VisibilityPublic, caperrs.OriginUser, caperrs.DeadlineExceeded)
 		err := caperrs.DeserializeErrorFromString(serialized, false)
 		deserialized := requireCapabilityError(t, err)
-		require.True(t, original.Equals(deserialized))
+		require.True(t, expected.Equals(deserialized))
 	})
 }

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -1,0 +1,166 @@
+package errors_test
+
+import (
+	stderrors "errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	caperrs "github.com/smartcontractkit/cre-sdk-go/capabilities/errors"
+)
+
+func requireCapabilityError(tb testing.TB, err error) caperrs.Error {
+	tb.Helper()
+	ce, ok := err.(caperrs.Error)
+	require.True(tb, ok, "expected capability errors.Error, got %T", err)
+	return ce
+}
+
+func TestErrorSerializationAndDeserialization(t *testing.T) {
+	visibilities := []caperrs.Visibility{caperrs.VisibilityPublic, caperrs.VisibilityPrivate}
+	origins := []caperrs.Origin{caperrs.OriginUser, caperrs.OriginSystem}
+	errorCodes := []caperrs.ErrorCode{caperrs.Unknown, caperrs.ConsensusFailed, caperrs.InvalidArgument}
+
+	for _, v := range visibilities {
+		for _, o := range origins {
+			for _, c := range errorCodes {
+				originalErr := caperrs.NewError(stderrors.New("test error"), v, o, c)
+				serialized := originalErr.SerializeToString()
+				deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serialized, true))
+				if !originalErr.Equals(deserializedErr) {
+					t.Errorf("expected %v, got %v", originalErr, deserializedErr)
+				}
+			}
+		}
+	}
+}
+
+func TestRemoteErrorSerializationAndDeserialization(t *testing.T) {
+	visibilities := []caperrs.Visibility{caperrs.VisibilityPublic, caperrs.VisibilityPrivate}
+	origins := []caperrs.Origin{caperrs.OriginUser, caperrs.OriginSystem}
+	errorCodes := []caperrs.ErrorCode{caperrs.Unknown, caperrs.ConsensusFailed, caperrs.InvalidArgument}
+
+	for _, v := range visibilities {
+		for _, o := range origins {
+			for _, c := range errorCodes {
+				originalErr := caperrs.NewError(stderrors.New("test error"), v, o, c)
+				serialized := originalErr.SerializeToRemoteString()
+				deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serialized, true))
+				if v == caperrs.VisibilityPrivate {
+					require.Equal(t, deserializedErr.Visibility(), originalErr.Visibility())
+					require.Equal(t, deserializedErr.Origin(), originalErr.Origin())
+					require.Equal(t, deserializedErr.Code(), originalErr.Code())
+					require.True(t, strings.Contains(deserializedErr.Error(), "error whilst executing capability - the error message is not publicly reportable"))
+				} else {
+					if !originalErr.Equals(deserializedErr) {
+						t.Errorf("expected %v, got %v", originalErr, deserializedErr)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestParsingOldErrorFormat(t *testing.T) {
+	oldErrorMsgString := "failed to execute capability: some error occurred"
+	deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(oldErrorMsgString, true))
+
+	expectedErr := caperrs.NewError(stderrors.New(oldErrorMsgString), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
+	if !deserializedErr.Equals(expectedErr) {
+		t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
+	}
+}
+
+func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibility(t *testing.T) {
+	t.Run("InvalidVisibility", func(t *testing.T) {
+		serializedError := "InvalidVisibility:User:Unknown:some error occurred"
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
+		require.False(t, caperrs.IsSerializedCapabilityErrorString(serializedError))
+		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
+		if !deserializedErr.Equals(expectedErr) {
+			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
+		}
+	})
+
+	t.Run("InvalidOrigin", func(t *testing.T) {
+		serializedError := "Public:InvalidOrigin:Unknown:some error occurred"
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
+		require.False(t, caperrs.IsSerializedCapabilityErrorString(serializedError))
+		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
+		if !deserializedErr.Equals(expectedErr) {
+			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
+		}
+	})
+
+	t.Run("InvalidErrorCode", func(t *testing.T) {
+		serializedError := "Public:System:InvalidErrorCode:some error occurred"
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
+		require.False(t, caperrs.IsSerializedCapabilityErrorString(serializedError))
+		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
+		if !deserializedErr.Equals(expectedErr) {
+			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
+		}
+	})
+
+	t.Run("InvalidMessageInsufficientFields", func(t *testing.T) {
+		msg := "Public:System:Unknown"
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
+
+		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
+		if !deserializedErr.Equals(expectedErr) {
+			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
+		}
+	})
+
+	t.Run("NotASerializedCapabilityError", func(t *testing.T) {
+		msg := "some error has occurred that is not in the serialized capability error format"
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
+
+		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
+		if !deserializedErr.Equals(expectedErr) {
+			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
+		}
+	})
+
+	t.Run("ColonRichPlainMessageMatchingUnknownCode", func(t *testing.T) {
+		// Four segments with a known error code token but invalid visibility — legacy wrap.
+		msg := "failed: attempt: Unknown: details here"
+		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
+		require.False(t, caperrs.IsSerializedCapabilityErrorString(msg))
+		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
+		require.True(t, deserializedErr.Equals(expectedErr))
+	})
+}
+
+func TestIsSerializedCapabilityErrorString(t *testing.T) {
+	valid := caperrs.NewError(stderrors.New("detail"), caperrs.VisibilityPublic, caperrs.OriginSystem, caperrs.InvalidArgument).SerializeToString()
+	require.True(t, caperrs.IsSerializedCapabilityErrorString(valid))
+
+	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:System"))
+	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:System:Unknown"))
+	require.True(t, caperrs.IsSerializedCapabilityErrorString("Public:System:Unknown:"))
+	require.True(t, caperrs.IsSerializedCapabilityErrorString("Public:System:Unknown:x"))
+
+	require.False(t, caperrs.IsSerializedCapabilityErrorString("InvalidVisibility:User:Unknown:msg"))
+	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:InvalidOrigin:Unknown:msg"))
+	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:System:InvalidErrorCode:msg"))
+}
+
+func TestDeserializeErrorFromString_withoutCapabilityWrap(t *testing.T) {
+	t.Run("plain message returns stdlib error", func(t *testing.T) {
+		msg := "some plain failure"
+		err := caperrs.DeserializeErrorFromString(msg, false)
+		require.Equal(t, msg, err.Error())
+		_, ok := err.(caperrs.Error)
+		require.False(t, ok)
+	})
+
+	t.Run("valid serialized still returns capability error", func(t *testing.T) {
+		original := caperrs.NewError(stderrors.New("detail"), caperrs.VisibilityPublic, caperrs.OriginUser, caperrs.DeadlineExceeded)
+		serialized := original.SerializeToString()
+		err := caperrs.DeserializeErrorFromString(serialized, false)
+		deserialized := requireCapabilityError(t, err)
+		require.True(t, original.Equals(deserialized))
+	})
+}

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -16,12 +16,19 @@ func requireCapabilityError(tb testing.TB, err error) caperrs.Error {
 	return ce
 }
 
+func capabilityErrorsEqual(a, b caperrs.Error) bool {
+	return a.Code() == b.Code() &&
+		a.Origin() == b.Origin() &&
+		a.Visibility() == b.Visibility() &&
+		a.Error() == b.Error()
+}
+
 func TestParsingOldErrorFormat(t *testing.T) {
 	oldErrorMsgString := "failed to execute capability: some error occurred"
 	deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(oldErrorMsgString, true))
 
 	expectedErr := caperrs.NewError(stderrors.New(oldErrorMsgString), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-	if !deserializedErr.Equals(expectedErr) {
+	if !capabilityErrorsEqual(deserializedErr, expectedErr) {
 		t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
 	}
 }
@@ -31,7 +38,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 		serializedError := "InvalidVisibility:User:Unknown:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
 		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !deserializedErr.Equals(expectedErr) {
+		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
 		}
 	})
@@ -40,7 +47,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 		serializedError := "Public:InvalidOrigin:Unknown:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
 		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !deserializedErr.Equals(expectedErr) {
+		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
 		}
 	})
@@ -49,7 +56,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 		serializedError := "Public:System:InvalidErrorCode:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
 		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !deserializedErr.Equals(expectedErr) {
+		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
 		}
 	})
@@ -59,7 +66,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
 
 		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !deserializedErr.Equals(expectedErr) {
+		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
 		}
 	})
@@ -69,7 +76,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
 
 		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		if !deserializedErr.Equals(expectedErr) {
+		if !capabilityErrorsEqual(deserializedErr, expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
 		}
 	})
@@ -79,7 +86,7 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 		msg := "failed: attempt: Unknown: details here"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
 		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
-		require.True(t, deserializedErr.Equals(expectedErr))
+		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 	})
 }
 
@@ -97,6 +104,6 @@ func TestDeserializeErrorFromString_withoutCapabilityWrap(t *testing.T) {
 		expected := caperrs.NewError(stderrors.New("detail"), caperrs.VisibilityPublic, caperrs.OriginUser, caperrs.DeadlineExceeded)
 		err := caperrs.DeserializeErrorFromString(serialized, false)
 		deserialized := requireCapabilityError(t, err)
-		require.True(t, expected.Equals(deserialized))
+		require.True(t, capabilityErrorsEqual(expected, deserialized))
 	})
 }

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -33,6 +33,7 @@ func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
 		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.Visibility(-1), caperrs.OriginUser, caperrs.Unknown)
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
+		require.Equal(t, "UnknownVisibility", deserializedErr.Visibility().String())
 	})
 
 	t.Run("InvalidOrigin", func(t *testing.T) {
@@ -40,6 +41,7 @@ func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
 		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.VisibilityPublic, caperrs.Origin(-1), caperrs.Unknown)
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
+		require.Equal(t, "UnknownOrigin", deserializedErr.Origin().String())
 	})
 
 	t.Run("NewUnknownErrorCode", func(t *testing.T) {
@@ -47,6 +49,8 @@ func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError))
 		expectedErr := caperrs.NewError(stderrors.New("some error occurred"), caperrs.VisibilityPublic, caperrs.OriginSystem, caperrs.ErrorCode(-1))
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
+		require.Equal(t, "UnknownErrorCode", deserializedErr.Code().String())
+		require.Equal(t, "[-1]UnknownErrorCode: some error occurred", deserializedErr.Error())
 	})
 
 	t.Run("ColonRichPlainMessageMatchingUnknownCode", func(t *testing.T) {
@@ -56,6 +60,15 @@ func TestDeserializeErrorFromStringInvalidFields(t *testing.T) {
 		expectedErr := caperrs.NewError(stderrors.New(" details here"), caperrs.Visibility(-1), caperrs.Origin(-1), caperrs.Unknown)
 		require.True(t, capabilityErrorsEqual(deserializedErr, expectedErr))
 	})
+}
+
+func TestUnknownValueStringOutput(t *testing.T) {
+	require.Equal(t, "UnknownOrigin", caperrs.Origin(-1).String())
+	require.Equal(t, "UnknownVisibility", caperrs.Visibility(-1).String())
+	require.Equal(t, "UnknownErrorCode", caperrs.ErrorCode(-1).String())
+
+	err := caperrs.NewError(stderrors.New("detail"), caperrs.Visibility(-1), caperrs.Origin(-1), caperrs.ErrorCode(-1))
+	require.Equal(t, "[-1]UnknownErrorCode: detail", err.Error())
 }
 
 func TestDeserializeErrorFromStringNonWireFormat(t *testing.T) {

--- a/capabilities/errors/error_serialization_test.go
+++ b/capabilities/errors/error_serialization_test.go
@@ -30,7 +30,6 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 	t.Run("InvalidVisibility", func(t *testing.T) {
 		serializedError := "InvalidVisibility:User:Unknown:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
-		require.False(t, caperrs.IsSerializedCapabilityErrorString(serializedError))
 		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		if !deserializedErr.Equals(expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
@@ -40,7 +39,6 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 	t.Run("InvalidOrigin", func(t *testing.T) {
 		serializedError := "Public:InvalidOrigin:Unknown:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
-		require.False(t, caperrs.IsSerializedCapabilityErrorString(serializedError))
 		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		if !deserializedErr.Equals(expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
@@ -50,7 +48,6 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 	t.Run("InvalidErrorCode", func(t *testing.T) {
 		serializedError := "Public:System:InvalidErrorCode:some error occurred"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(serializedError, true))
-		require.False(t, caperrs.IsSerializedCapabilityErrorString(serializedError))
 		expectedErr := caperrs.NewError(stderrors.New(serializedError), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		if !deserializedErr.Equals(expectedErr) {
 			t.Errorf("expected %v, got %v", expectedErr, deserializedErr)
@@ -81,23 +78,9 @@ func TestParsingWithInvalidVisibilityOriginAndErrorCodesAndBackwardsCompatibilit
 		// Four segments with a known error code token but invalid visibility — legacy wrap.
 		msg := "failed: attempt: Unknown: details here"
 		deserializedErr := requireCapabilityError(t, caperrs.DeserializeErrorFromString(msg, true))
-		require.False(t, caperrs.IsSerializedCapabilityErrorString(msg))
 		expectedErr := caperrs.NewError(stderrors.New(msg), caperrs.VisibilityPrivate, caperrs.OriginSystem, caperrs.Unknown)
 		require.True(t, deserializedErr.Equals(expectedErr))
 	})
-}
-
-func TestIsSerializedCapabilityErrorString(t *testing.T) {
-	require.True(t, caperrs.IsSerializedCapabilityErrorString("Public:System:InvalidArgument:detail"))
-
-	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:System"))
-	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:System:Unknown"))
-	require.True(t, caperrs.IsSerializedCapabilityErrorString("Public:System:Unknown:"))
-	require.True(t, caperrs.IsSerializedCapabilityErrorString("Public:System:Unknown:x"))
-
-	require.False(t, caperrs.IsSerializedCapabilityErrorString("InvalidVisibility:User:Unknown:msg"))
-	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:InvalidOrigin:Unknown:msg"))
-	require.False(t, caperrs.IsSerializedCapabilityErrorString("Public:System:InvalidErrorCode:msg"))
 }
 
 func TestDeserializeErrorFromString_withoutCapabilityWrap(t *testing.T) {

--- a/generator/protoc-gen-cre/pkg/templates/sdk.go.tmpl
+++ b/generator/protoc-gen-cre/pkg/templates/sdk.go.tmpl
@@ -4,6 +4,7 @@ import (
     "errors"
     "google.golang.org/protobuf/types/known/anypb"
 
+    caperrors "github.com/smartcontractkit/cre-sdk-go/capabilities/errors"
     "github.com/smartcontractkit/cre-sdk-go/cre"
     sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 

--- a/generator/protoc-gen-cre/pkg/templates/sdk_action.go.tmpl
+++ b/generator/protoc-gen-cre/pkg/templates/sdk_action.go.tmpl
@@ -46,7 +46,7 @@ func (c *{{.Service.GoName}}) {{.Method.GoName}}(runtime cre.{{.Mode}}Runtime, i
     }), func(i *sdkpb.CapabilityResponse) (*{{name .OutputType .GoPackageName}}, error) {
         switch payload := i.Response.(type) {
         case *sdkpb.CapabilityResponse_Error:
-            return nil, errors.New(payload.Error)
+            return nil, caperrors.DeserializeErrorFromString(payload.Error)
         case *sdkpb.CapabilityResponse_Payload:
             output := &{{name .OutputType .GoPackageName}}{}
             err = payload.Payload.UnmarshalTo(output)

--- a/internal_testing/capabilities/actionandtrigger/action_and_trigger_sdk_gen.go
+++ b/internal_testing/capabilities/actionandtrigger/action_and_trigger_sdk_gen.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+	caperrors "github.com/smartcontractkit/cre-sdk-go/capabilities/errors"
 	"github.com/smartcontractkit/cre-sdk-go/cre"
 )
 
@@ -30,7 +31,7 @@ func (c *Basic) Action(runtime cre.Runtime, input *Input) cre.Promise[*Output] {
 	}), func(i *sdkpb.CapabilityResponse) (*Output, error) {
 		switch payload := i.Response.(type) {
 		case *sdkpb.CapabilityResponse_Error:
-			return nil, errors.New(payload.Error)
+			return nil, caperrors.DeserializeErrorFromString(payload.Error)
 		case *sdkpb.CapabilityResponse_Payload:
 			output := &Output{}
 			err = payload.Payload.UnmarshalTo(output)

--- a/internal_testing/capabilities/basicaction/basic_action_sdk_gen.go
+++ b/internal_testing/capabilities/basicaction/basic_action_sdk_gen.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+	caperrors "github.com/smartcontractkit/cre-sdk-go/capabilities/errors"
 	"github.com/smartcontractkit/cre-sdk-go/cre"
 )
 
@@ -32,7 +33,7 @@ func (c *BasicAction) PerformAction(runtime cre.Runtime, input *Inputs) cre.Prom
 	}), func(i *sdkpb.CapabilityResponse) (*Outputs, error) {
 		switch payload := i.Response.(type) {
 		case *sdkpb.CapabilityResponse_Error:
-			return nil, errors.New(payload.Error)
+			return nil, caperrors.DeserializeErrorFromString(payload.Error)
 		case *sdkpb.CapabilityResponse_Payload:
 			output := &Outputs{}
 			err = payload.Payload.UnmarshalTo(output)

--- a/internal_testing/capabilities/consensus/consensus_sdk_gen.go
+++ b/internal_testing/capabilities/consensus/consensus_sdk_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
+	caperrors "github.com/smartcontractkit/cre-sdk-go/capabilities/errors"
 	"github.com/smartcontractkit/cre-sdk-go/cre"
 )
 
@@ -32,7 +33,7 @@ func (c *Consensus) Simple(runtime cre.Runtime, input *sdk.SimpleConsensusInputs
 	}), func(i *sdkpb.CapabilityResponse) (*pb.Value, error) {
 		switch payload := i.Response.(type) {
 		case *sdkpb.CapabilityResponse_Error:
-			return nil, errors.New(payload.Error)
+			return nil, caperrors.DeserializeErrorFromString(payload.Error)
 		case *sdkpb.CapabilityResponse_Payload:
 			output := &pb.Value{}
 			err = payload.Payload.UnmarshalTo(output)
@@ -60,7 +61,7 @@ func (c *Consensus) Report(runtime cre.Runtime, input *sdk.ReportRequest) cre.Pr
 	}), func(i *sdkpb.CapabilityResponse) (*sdk.ReportResponse, error) {
 		switch payload := i.Response.(type) {
 		case *sdkpb.CapabilityResponse_Error:
-			return nil, errors.New(payload.Error)
+			return nil, caperrors.DeserializeErrorFromString(payload.Error)
 		case *sdkpb.CapabilityResponse_Payload:
 			output := &sdk.ReportResponse{}
 			err = payload.Payload.UnmarshalTo(output)

--- a/internal_testing/capabilities/importclash/clash_sdk_gen.go
+++ b/internal_testing/capabilities/importclash/clash_sdk_gen.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+	caperrors "github.com/smartcontractkit/cre-sdk-go/capabilities/errors"
 	"github.com/smartcontractkit/cre-sdk-go/cre"
 	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/importclash/p1"
 	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/importclash/p2"
@@ -32,7 +33,7 @@ func (c *BasicAction) PerformAction(runtime cre.Runtime, input *p1.Item) cre.Pro
 	}), func(i *sdkpb.CapabilityResponse) (*p2.Item, error) {
 		switch payload := i.Response.(type) {
 		case *sdkpb.CapabilityResponse_Error:
-			return nil, errors.New(payload.Error)
+			return nil, caperrors.DeserializeErrorFromString(payload.Error)
 		case *sdkpb.CapabilityResponse_Payload:
 			output := &p2.Item{}
 			err = payload.Payload.UnmarshalTo(output)

--- a/internal_testing/capabilities/nodeaction/node_action_sdk_gen.go
+++ b/internal_testing/capabilities/nodeaction/node_action_sdk_gen.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	sdkpb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
+	caperrors "github.com/smartcontractkit/cre-sdk-go/capabilities/errors"
 	"github.com/smartcontractkit/cre-sdk-go/cre"
 )
 
@@ -55,7 +56,7 @@ func (c *BasicAction) PerformAction(runtime cre.NodeRuntime, input *NodeInputs) 
 	}), func(i *sdkpb.CapabilityResponse) (*NodeOutputs, error) {
 		switch payload := i.Response.(type) {
 		case *sdkpb.CapabilityResponse_Error:
-			return nil, errors.New(payload.Error)
+			return nil, caperrors.DeserializeErrorFromString(payload.Error)
 		case *sdkpb.CapabilityResponse_Payload:
 			output := &NodeOutputs{}
 			err = payload.Payload.UnmarshalTo(output)

--- a/standard_tests/capability_errors/main_wasip1.go
+++ b/standard_tests/capability_errors/main_wasip1.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/smartcontractkit/cre-sdk-go/cre"
+	"github.com/smartcontractkit/cre-sdk-go/cre/wasm"
+	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger"
+)
+
+func main() {
+	runner := wasm.NewRunner(func(configBytes []byte) ([]byte, error) {
+		return configBytes, nil
+	})
+	runner.Run(initFn)
+}
+
+func initFn([]byte, *slog.Logger, cre.SecretsProvider) (cre.Workflow[[]byte], error) {
+	return cre.Workflow[[]byte]{
+		cre.Handler(
+			basictrigger.Trigger(&basictrigger.Config{}),
+			returnConfig,
+		),
+	}, nil
+}
+
+func returnConfig([]byte, cre.Runtime, *basictrigger.Outputs) ([]byte, error) {
+	return nil, errors.New("workflow execution failure")
+}

--- a/standard_tests/capability_errors/main_wasip1.go
+++ b/standard_tests/capability_errors/main_wasip1.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	"errors"
+	"fmt"
 	"log/slog"
 
+	caperrors "github.com/smartcontractkit/cre-sdk-go/capabilities/errors"
 	"github.com/smartcontractkit/cre-sdk-go/cre"
 	"github.com/smartcontractkit/cre-sdk-go/cre/wasm"
+	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basicaction"
 	"github.com/smartcontractkit/cre-sdk-go/internal_testing/capabilities/basictrigger"
 )
 
@@ -20,11 +22,30 @@ func initFn([]byte, *slog.Logger, cre.SecretsProvider) (cre.Workflow[[]byte], er
 	return cre.Workflow[[]byte]{
 		cre.Handler(
 			basictrigger.Trigger(&basictrigger.Config{}),
-			returnConfig,
+			checkCapabilityErrors,
 		),
 	}, nil
 }
 
-func returnConfig([]byte, cre.Runtime, *basictrigger.Outputs) ([]byte, error) {
-	return nil, errors.New("workflow execution failure")
+func checkCapabilityErrors(_ []byte, rt cre.Runtime, _ *basictrigger.Outputs) (string, error) {
+	action := basicaction.BasicAction{}
+	input := &basicaction.Inputs{InputThing: true}
+
+	for {
+		output, err := action.PerformAction(rt, input).Await()
+		if err == nil {
+			if output.AdaptedThing != "Done" {
+				return "", fmt.Errorf("expected Done response, got %s", output.AdaptedThing)
+			}
+			return "Done", nil
+		}
+
+		capErr, ok := err.(caperrors.Error)
+		if !ok {
+			return "", fmt.Errorf("expected capability error, got %T: %v", err, err)
+		}
+		if capErr.Code() == caperrors.UnrecognisedErrorCode {
+			return "", fmt.Errorf("expected recognised error code, got UnrecognisedErrorCode")
+		}
+	}
 }


### PR DESCRIPTION
Changes required to support typed capability errors in the cre go SDK.  Also, includes the changes to be able to successfully run the TestStandardCapabilityErrors test defined in  https://github.com/smartcontractkit/chainlink-common/pull/2138.   This test ensures that the sdk will be updated when new error codes are added.  (Note, if unknown error codes are received they are handled gracefully by the sdk - defaulting to an UnrecognisedError code).