### PR TITLE
.github/workflows: Change trigger from push to pull_request

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -1,6 +1,6 @@
 name: PKG Build and Test
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build-test:

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -1,6 +1,10 @@
 name: PKG Build and Test
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build-test:


### PR DESCRIPTION
PR https://github.com/smartcontractkit/cre-sdk-go/pull/188 is blocked on things that are not triggering. I suspect related to how CI had to be approved to run since it was created by a bot.