### PR TITLE
fix: harden consensus tag parsing and runtime input validation

### DIFF
--- a/cre/consensus_aggregators.go
+++ b/cre/consensus_aggregators.go
@@ -1,6 +1,7 @@
 package cre
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -61,7 +62,7 @@ func ConsensusCommonSuffixAggregation[T any]() func() (ConsensusAggregation[[]T]
 			return &consensusDescriptor[[]T]{Descriptor_: &sdk.ConsensusDescriptor_Aggregation{Aggregation: sdk.AggregationType_AGGREGATION_TYPE_COMMON_SUFFIX}}, nil
 		}
 
-		return &consensusDescriptor[[]T]{}, fmt.Errorf("%T is not a valid type for common prefix consensus", t)
+		return &consensusDescriptor[[]T]{}, fmt.Errorf("%T is not a valid type for common suffix consensus", t)
 	}
 }
 
@@ -88,15 +89,34 @@ var (
 	bigIntType  = reflect.TypeOf((*big.Int)(nil))
 	timeType    = reflect.TypeOf(time.Time{})
 	decimalType = reflect.TypeOf(decimal.Decimal{})
+
+	// maxConsensusDepth bounds the recursion depth of parseConsensusTag and
+	// isIdenticalType when processing nested/squashed struct fields and
+	// composite types. It protects against deeply-nested or self-referential
+	// (via pointers) type definitions that could otherwise exhaust the call
+	// stack during reflection. The limit is generous enough for any realistic
+	// struct graph while keeping reflection bounded.
+	maxConsensusDepth = 100
 )
 
 func parseConsensusTag(t reflect.Type, path string) (*sdk.ConsensusDescriptor, error) {
+	return parseConsensusTagDepth(t, path, 0)
+}
+
+func parseConsensusTagDepth(t reflect.Type, path string, depth int) (*sdk.ConsensusDescriptor, error) {
+	if t == nil {
+		return nil, errors.New("ConsensusAggregationFromTags expects a non-nil type")
+	}
 	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
 	if t.Kind() != reflect.Struct {
 		return nil, fmt.Errorf("ConsensusAggregationFromTags expects a struct type, got %s", t.Kind())
+	}
+
+	if depth >= maxConsensusDepth {
+		return nil, fmt.Errorf("ConsensusAggregationFromTags exceeded max recursion depth %d at %s", maxConsensusDepth, path)
 	}
 
 	descriptors := make(map[string]*sdk.ConsensusDescriptor)
@@ -125,7 +145,7 @@ func parseConsensusTag(t reflect.Type, path string) (*sdk.ConsensusDescriptor, e
 		}
 
 		if len(mapstructureTagParts) > 1 && mapstructureTagParts[1] == "squash" {
-			inner, err := parseConsensusTag(field.Type, path+field.Name+".")
+			inner, err := parseConsensusTagDepth(field.Type, path+field.Name+".", depth+1)
 			if err != nil {
 				return nil, fmt.Errorf("nested field %s: %w", field.Name, err)
 			}
@@ -164,7 +184,7 @@ func parseConsensusTag(t reflect.Type, path string) (*sdk.ConsensusDescriptor, e
 			}
 			descriptors[serializedName] = &sdk.ConsensusDescriptor{Descriptor_: &sdk.ConsensusDescriptor_Aggregation{Aggregation: sdk.AggregationType_AGGREGATION_TYPE_COMMON_SUFFIX}}
 		case "nested":
-			descriptors[serializedName], err = parseConsensusTag(field.Type, path+field.Name+".")
+			descriptors[serializedName], err = parseConsensusTagDepth(field.Type, path+field.Name+".", depth+1)
 			if err != nil {
 				return nil, fmt.Errorf("nested field %s: %w", field.Name, err)
 			}
@@ -196,6 +216,16 @@ func isNumeric(t reflect.Type) bool {
 }
 
 func isIdenticalType(t reflect.Type) bool {
+	return isIdenticalTypeDepth(t, 0)
+}
+
+func isIdenticalTypeDepth(t reflect.Type, depth int) bool {
+	if t == nil {
+		return false
+	}
+	if depth >= maxConsensusDepth {
+		return false
+	}
 	switch t.Kind() {
 	case reflect.String, reflect.Bool,
 		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
@@ -203,22 +233,22 @@ func isIdenticalType(t reflect.Type) bool {
 		reflect.Float32, reflect.Float64:
 		return true
 	case reflect.Map:
-		return t.Key().Kind() == reflect.String && isIdenticalType(t.Elem())
+		return t.Key().Kind() == reflect.String && isIdenticalTypeDepth(t.Elem(), depth+1)
 	case reflect.Struct:
 		for i := 0; i < t.NumField(); i++ {
 			field := t.Field(i)
-			if field.IsExported() && !isIdenticalType(field.Type) {
+			if field.IsExported() && !isIdenticalTypeDepth(field.Type, depth+1) {
 				return false
 			}
 		}
 		return true
 	case reflect.Slice, reflect.Array:
-		return isIdenticalType(t.Elem())
+		return isIdenticalTypeDepth(t.Elem(), depth+1)
 	case reflect.Pointer:
 		if t == bigIntType {
 			return true
 		}
-		return t.Elem().Kind() != reflect.Pointer && isIdenticalType(t.Elem())
+		return t.Elem().Kind() != reflect.Pointer && isIdenticalTypeDepth(t.Elem(), depth+1)
 	default:
 		return false
 	}

--- a/cre/consensus_aggregators_test.go
+++ b/cre/consensus_aggregators_test.go
@@ -550,3 +550,61 @@ func testInvalidIdenticalFieldHelper[T any](t *testing.T) {
 	}]()
 	require.ErrorContains(t, desc.Err(), "field Val marked as identical but is not a valid type")
 }
+
+// TestConsensusCommonSuffixAggregation_ErrorMessage verifies that the error
+// message from ConsensusCommonSuffixAggregation references "suffix", not "prefix".
+func TestConsensusCommonSuffixAggregation_ErrorMessage(t *testing.T) {
+	_, err := cre.ConsensusCommonSuffixAggregation[[]chan int]()()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "common suffix consensus")
+	assert.NotContains(t, err.Error(), "common prefix consensus")
+}
+
+// TestConsensusAggregationFromTags_SelfReferentialNested verifies that a
+// self-referential struct (via a pointer field with a "nested" tag) does not
+// cause a stack overflow. The bounded recursion returns an error instead.
+func TestConsensusAggregationFromTags_SelfReferentialNested(t *testing.T) {
+	type SelfRef struct {
+		Val  int       `consensus_aggregation:"median"`
+		Next *SelfRef `consensus_aggregation:"nested"`
+	}
+
+	assert.NotPanics(t, func() {
+		desc := cre.ConsensusAggregationFromTags[SelfRef]()
+		require.Error(t, desc.Err())
+		assert.Contains(t, desc.Err().Error(), "max recursion depth")
+	})
+}
+
+// TestConsensusAggregationFromTags_SelfReferentialSquash verifies that a
+// self-referential struct via a pointer field with a ",squash" mapstructure
+// tag is also bounded and returns an error instead of stack-overflowing.
+func TestConsensusAggregationFromTags_SelfReferentialSquash(t *testing.T) {
+	type SelfRef struct {
+		Val  int      `consensus_aggregation:"median"`
+		Next *SelfRef `consensus_aggregation:"median" mapstructure:",squash"`
+	}
+
+	assert.NotPanics(t, func() {
+		desc := cre.ConsensusAggregationFromTags[SelfRef]()
+		require.Error(t, desc.Err())
+		assert.Contains(t, desc.Err().Error(), "max recursion depth")
+	})
+}
+
+// TestConsensusIdenticalAggregation_DeeplyNested verifies that isIdenticalType
+// bounds its recursion when processing a self-referential struct used with
+// ConsensusIdenticalAggregation, returning false instead of stack-overflowing.
+func TestConsensusIdenticalAggregation_DeeplyNested(t *testing.T) {
+	type SelfRef struct {
+		Val  int
+		Next *SelfRef
+	}
+
+	assert.NotPanics(t, func() {
+		desc := cre.ConsensusIdenticalAggregation[SelfRef]()
+		// isIdenticalType returns false at the depth limit, so the descriptor
+		// carries an "is not a valid type" error rather than panicking.
+		require.Error(t, desc.Err())
+	})
+}

--- a/cre/parsers.go
+++ b/cre/parsers.go
@@ -5,6 +5,17 @@ import (
 )
 
 // ParseJSON parses a JSON byte slice into a struct of type *T.
+//
+// ParseJSON is a thin typed wrapper around [encoding/json.Unmarshal]; it allocates
+// a new T, unmarshals into it, and returns a pointer to the result. All semantics
+// of json.Unmarshal apply, including how it handles JSON "null":
+//   - For non-pointer types (e.g. int), JSON "null" unmarshals to the zero value
+//     and a valid pointer to that zero value is returned.
+//   - For pointer types (e.g. *Foo), JSON "null" unmarshals to nil, so the
+//     returned **Foo points to a nil *Foo. Callers that dereference the result
+//     must account for this case.
+//
+// See [encoding/json.Unmarshal] for the full set of decoding rules.
 func ParseJSON[T any](bytes []byte) (*T, error) {
 	var result T
 	err := json.Unmarshal(bytes, &result)

--- a/cre/runtime.go
+++ b/cre/runtime.go
@@ -2,6 +2,7 @@ package cre
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"math/rand"
 	"reflect"
@@ -17,7 +18,12 @@ type Secret = sdk.Secret
 const DefaultSecretNamespace = "main"
 
 // RuntimeBase provides the basic functionality of a CRE runtime.
-// It is not thread safe and must not be used concurrently.
+//
+// It is not thread safe and must not be used concurrently. The runtime is
+// designed to execute within a single-threaded WASM guest environment, so the
+// internal state it tracks (including the call ID counter and the current mode)
+// is intentionally unsynchronized. Concurrent access from multiple goroutines
+// would race on that state and is unsupported by design.
 type RuntimeBase interface {
 	// CallCapability is meant to be called by generated code
 	CallCapability(request *sdk.CapabilityRequest) Promise[*sdk.CapabilityResponse]
@@ -43,8 +49,11 @@ type SecretsProvider interface {
 	GetSecrets([]*SecretRequest) Promise[[]*Secret]
 }
 
-// NodeRuntime provides access to Node capabilities
-// It is not thread safe and must not be used concurrently.
+// NodeRuntime provides access to Node capabilities.
+//
+// It is not thread safe and must not be used concurrently. Like RuntimeBase,
+// it is intended for the single-threaded WASM guest environment and its state
+// (including the call ID counter) is intentionally unsynchronized.
 type NodeRuntime interface {
 	RuntimeBase
 
@@ -53,7 +62,11 @@ type NodeRuntime interface {
 }
 
 // Runtime provides access to DON capabilities and allows NodeRuntime use with consensus.
-// It is not thread safe and must not be used concurrently.
+//
+// It is not thread safe and must not be used concurrently. The runtime targets
+// the single-threaded WASM guest environment, so shared state such as the call
+// ID counter and the mode/modeErr fields modified by RunInNodeMode is
+// intentionally unsynchronized. Concurrent use would race on that state.
 type Runtime interface {
 	RuntimeBase
 
@@ -78,10 +91,13 @@ type ConsensusAggregation[T any] interface {
 	// Descriptor is meant to be used by the Runtime
 	Descriptor() *sdk.ConsensusDescriptor
 
-	// Default returns the default value or nil when there is no default value
+	// Default returns the default value or nil when there is no default value.
+	// Callers must check for nil before dereferencing the returned pointer.
 	Default() *T
 
-	// Err is meant to be used by the Runtime
+	// Err is meant to be used by the Runtime. It returns nil when the
+	// ConsensusAggregation was constructed successfully, or a non-nil error
+	// (e.g. from an invalid type) otherwise. Callers must check for nil.
 	Err() error
 
 	// WithDefault returns a new ConsensusAggregation with the given default value
@@ -218,6 +234,9 @@ func RunInNodeMode[C, T any](
 		var err error
 
 		typ := reflect.TypeOf(t)
+		if typ == nil {
+			return t, fmt.Errorf("RunInNodeMode requires a concrete type for T, got nil reflect.Type")
+		}
 		// If T is a pointer type, we need to allocate the underlying type and pass its pointer to UnwrapTo
 		if typ.Kind() == reflect.Ptr {
 			elem := reflect.New(typ.Elem())

--- a/internal/sdkimpl/runtime.go
+++ b/internal/sdkimpl/runtime.go
@@ -1,6 +1,7 @@
 package sdkimpl
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand"
@@ -27,6 +28,12 @@ type RuntimeHelpers interface {
 	Now() time.Time
 }
 
+// RuntimeBase is the internal implementation of cre.RuntimeBase.
+//
+// It is not thread safe and must not be used concurrently. The runtime is
+// designed to execute within a single-threaded WASM guest environment, so the
+// call ID counter (nextCallId) and mode state (modeErr, Mode) are intentionally
+// unsynchronized. Concurrent access would race on that state.
 type RuntimeBase struct {
 	MaxResponseSize uint64
 	RuntimeHelpers
@@ -59,6 +66,10 @@ var (
 )
 
 func (r *RuntimeBase) CallCapability(request *sdk.CapabilityRequest) cre.Promise[*sdk.CapabilityResponse] {
+	if request == nil {
+		return cre.PromiseFromResult[*sdk.CapabilityResponse](nil, errors.New("CallCapability requires a non-nil request"))
+	}
+
 	if r.Mode == sdk.Mode_MODE_DON {
 		r.nextCallId++
 	} else {
@@ -139,6 +150,10 @@ func normalizeSecretRequests(reqs []*sdk.SecretRequest) []*sdk.SecretRequest {
 }
 
 func (d *Runtime) GetSecret(req *sdk.SecretRequest) cre.Promise[*sdk.Secret] {
+	if req == nil {
+		return cre.PromiseFromResult[*sdk.Secret](nil, errors.New("GetSecret requires a non-nil request"))
+	}
+
 	return cre.Then(d.GetSecrets([]*sdk.SecretRequest{req}), func(secrets []*sdk.Secret) (*sdk.Secret, error) {
 		if len(secrets) != 1 {
 			return nil, fmt.Errorf("expected 1 secret, got %d", len(secrets))
@@ -199,6 +214,10 @@ func (d *Runtime) GetSecrets(reqs []*sdk.SecretRequest) cre.Promise[[]*sdk.Secre
 	})
 }
 
+// RunInNodeMode switches the runtime into node mode, runs fn, then switches
+// back to DON mode. It modifies the shared modeErr and Mode fields without
+// synchronization; this is safe because the runtime is single-threaded by
+// design (see the RuntimeBase godoc) and must not be used concurrently.
 func (d *Runtime) RunInNodeMode(fn func(nodeRuntime cre.NodeRuntime) *sdk.SimpleConsensusInputs) cre.Promise[values.Value] {
 	nodeBase := d.RuntimeBase
 	nodeBase.Mode = sdk.Mode_MODE_NODE

--- a/internal/sdkimpl/runtime_test.go
+++ b/internal/sdkimpl/runtime_test.go
@@ -392,3 +392,29 @@ type awaitOverride struct {
 func (a *awaitOverride) Await(request *sdk.AwaitCapabilitiesRequest, maxResponseSize uint64) (*sdk.AwaitCapabilitiesResponse, error) {
 	return a.await(request, maxResponseSize)
 }
+
+// TestRuntime_CallCapability_NilRequest verifies that a nil request returns an
+// error promise instead of panicking on a nil-pointer dereference.
+func TestRuntime_CallCapability_NilRequest(t *testing.T) {
+	runtime := testutils.NewRuntime(t, nil)
+
+	assert.NotPanics(t, func() {
+		promise := runtime.CallCapability(nil)
+		_, err := promise.Await()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-nil request")
+	})
+}
+
+// TestRuntime_GetSecret_NilRequest verifies that a nil request returns an
+// error promise instead of panicking on a nil-pointer dereference.
+func TestRuntime_GetSecret_NilRequest(t *testing.T) {
+	runtime := testutils.NewRuntime(t, nil)
+
+	assert.NotPanics(t, func() {
+		promise := runtime.GetSecret(nil)
+		_, err := promise.Await()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-nil request")
+	})
+}


### PR DESCRIPTION
- Fix misleading error message in ConsensusCommonSuffixAggregation ("common prefix" -> "common suffix")
- Add nil checks to CallCapability and GetSecret to return an error promise instead of panicking on nil input
- Bound recursion depth in parseConsensusTag and isIdenticalType to prevent stack overflow on self-referential struct types
- Add nil guard for reflect.TypeOf in RunInNodeMode
- Document ParseJSON json.Unmarshal semantics including pointer/null
- Document that Default() and Err() may return nil on ConsensusAggregation interface
- Reinforce single-threaded usage docs on RuntimeBase, NodeRuntime, Runtime, and RunInNodeMode

Includes unit tests for the nil checks, bounded recursion, and corrected error message.